### PR TITLE
add signal->span-attrs-fn option to opentelemetry handler

### DIFF
--- a/projects/main/src/taoensso/telemere/open_telemetry.clj
+++ b/projects/main/src/taoensso/telemere/open_telemetry.clj
@@ -30,7 +30,7 @@
 
 ;;;; Attributes
 
-(def ^:private ^String attr-name
+(def ^String attr-name
   "Returns cached OpenTelemetry-style name: `:a.b/c-d` -> \"a.b.c_d\", etc.
   Ref. <https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/>."
   (enc/fmemoize
@@ -82,10 +82,10 @@
     (when-let [^String s (enc/catching :common (enc/pr-edn* v))]
       (.put ab k s))))
 
-(defmacro ^:private put-attr! [attr-builder attr-name attr-val]
+(defmacro put-attr! [attr-builder attr-name attr-val]
   `(-put-attr! ~attr-val ~attr-name ~attr-builder)) ; Fix arg order
 
-(defn- merge-attrs!
+(defn merge-attrs!
   "If given a map, merges prefixed key/values (~like `into`).
   Otherwise just puts single named value."
   [attr-builder name-or-prefix x]
@@ -120,7 +120,7 @@
       :report "INFO4"
       (str level))))
 
-(defn- signal->attrs
+(defn signal->attrs
   "Returns `Attributes` for given signal.
   Ref. <https://opentelemetry.io/docs/specs/otel/logs/data-model/>."
   ^Attributes [signal]

--- a/projects/main/src/taoensso/telemere/open_telemetry.clj
+++ b/projects/main/src/taoensso/telemere/open_telemetry.clj
@@ -220,7 +220,8 @@
 
   Options:
     `:logger-provider` - nil or `io.opentelemetry.api.logs.LoggerProvider`,
-      (see `telemere/otel-default-providers_` for default)."
+      (see `telemere/otel-default-providers_` for default).
+    `:emit-tracing?` - set to `false` to disable tracing.
 
   ;; Notes:
   ;; - Multi-threaded handlers may see signals ~out of order


### PR DESCRIPTION
this PR adds a `:signal->span-attrs-fn` option to the opentelemetry handler for adding custom signal attributes to the corresponding opentelemetry span.

the existing `signal->attrs` fn seems to be intended for log records and i'm not sure whether the result would be a good default for spans as well, so i've just made it public to have it available as an option.  

i've made the helper functions public as well to aid in creating a custom `signal->span-attrs-fn`