### PR TITLE
Wiki fixes

### DIFF
--- a/wiki/3-Config.md
+++ b/wiki/3-Config.md
@@ -103,7 +103,7 @@ Aside from configuring the exporters (2), Telemere's OpenTelemetry interop **doe
 
 ## Tufte
 
-> [Tufte](https:/www.taoensso.com/tufte) is a simple performance monitoring library for Clojure/Script by the author of Telemere.
+> [Tufte](https://www.taoensso.com/tufte) is a simple performance monitoring library for Clojure/Script by the author of Telemere.
 
 Telemere can easily incorporate Tufte performance data in its signals, just like any other data:
 
@@ -115,7 +115,7 @@ Telemere can easily incorporate Tufte performance data in its signals, just like
 Telemere and Tufte work great together:
 
 - Their functionality is complementary.
-- The [upcoming](https:/www.taoensso.com/roadmap) Tufte v3 will share the same core as Telemere and offer an **identical API** for managing filters and handlers.
+- The [upcoming](https://www.taoensso.com/roadmap) Tufte v3 will share the same core as Telemere and offer an **identical API** for managing filters and handlers.
 
 ## Truss
 

--- a/wiki/3-Config.md
+++ b/wiki/3-Config.md
@@ -109,7 +109,7 @@ Telemere can easily incorporate Tufte performance data in its signals, just like
 
 ```clojure
 (let [[_ perf-data] (tufte/profiled <opts> <form>)]
-  (t/log! "Performance data" {:perf-data perf-data}))
+  (t/log! {:perf-data perf-data}  "Performance data"))
 ```
 
 Telemere and Tufte work great together:

--- a/wiki/6-FAQ.md
+++ b/wiki/6-FAQ.md
@@ -1,6 +1,6 @@
 # Does Telemere replace Timbre?
 
-> [Timbre](https:/www.taoensso.com/timbre) is a pure Clojure/Script logging library, and ancestor of Telemere.
+> [Timbre](https://www.taoensso.com/timbre) is a pure Clojure/Script logging library, and ancestor of Telemere.
 
 **Yes**, Telemere's functionality is a **superset of Timbre**, and offers *many* improvements over Timbre.
 
@@ -12,7 +12,7 @@ See section [5-Migrating](./5-Migrating#from-timbre) for migration info.
 
 # Why not just update Timbre?
 
-> [Timbre](https:/www.taoensso.com/timbre) is a pure Clojure/Script logging library, and ancestor of Telemere.
+> [Timbre](https://www.taoensso.com/timbre) is a pure Clojure/Script logging library, and ancestor of Telemere.
 
 Why release Telemere as a *new library* instead of just updating Timbre?
 
@@ -32,9 +32,9 @@ This will eventually ease long-term maintenance, increase reliability, and help 
 
 # Does Telemere replace Tufte?
 
-> [Tufte](https:/www.taoensso.com/tufte) is a simple performance monitoring library for Clojure/Script by the author of Telemere.
+> [Tufte](https://www.taoensso.com/tufte) is a simple performance monitoring library for Clojure/Script by the author of Telemere.
 
-**No**, Telemere does **not** replace [Tufte](https:/www.taoensso.com/tufte). They work great together, and the [upcoming](https:/www.taoensso.com/roadmap) Tufte v3 will share the same core as Telemere and offer an **identical API** for managing filters and handlers.
+**No**, Telemere does **not** replace [Tufte](https://www.taoensso.com/tufte). They work great together, and the [upcoming](https://www.taoensso.com/roadmap) Tufte v3 will share the same core as Telemere and offer an **identical API** for managing filters and handlers.
 
 There is **some feature overlap** though since Telemere offers basic performance measurement as part of its tracing features.
 


### PR DESCRIPTION
some links were not working and the tufte example had the args of `log!` in wrong order