### PR TITLE
Note that ns filters work for SLF4J logger names too

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,12 @@ It enables you to write code that is **information-verbose by default**.
 (t/set-min-level!       :warn) ; For all    signals
 (t/set-min-level! :log :debug) ; For `log!` signals only
 
-;; Set namespace and id filters
-(t/set-ns-filter! {:disallow "taoensso.*" :allow "taoensso.sente.*"})
+;; Set id and namespace filters
 (t/set-id-filter! {:allow #{::my-particular-id "my-app/*"}})
+(t/set-ns-filter! {:disallow "taoensso.*" :allow "taoensso.sente.*"})
+;; SLF4j (and by extension JUL) events will have a ":ns" set to the logger
+;; name so ns filtering works for loggers too:
+(t/set-ns-filter! {:disallow "com.noisy.java.package.*"})
 
 ;; Set minimum level for `event!` signals for particular ns pattern
 (t/set-min-level! :event "taoensso.sente.*" :warn)


### PR DESCRIPTION
(I flipped the order of ns/id filters to be a bit less of a sequence break since I'm saying something extra about ns filters.)