### PR TITLE
Add support for otel span kind

### DIFF
--- a/projects/main/src/taoensso/telemere/impl.cljc
+++ b/projects/main/src/taoensso/telemere/impl.cljc
@@ -220,17 +220,24 @@
          We leave the (expensive) population of attributes, etc. for signal handler.
          Interop needs only the basics (t0, traceId, spanId, spanName) right away."
          ^io.opentelemetry.context.Context
-         [id inst ?parent-context]
+         [id inst ?parent-context span-kind]
          (let [parent-context (or ?parent-context (otel-context))]
            (enc/if-not [tracer (force taoensso.telemere/*otel-tracer*)]
              parent-context ; Can't add Span without Tracer
              (let [sb (.spanBuilder ^io.opentelemetry.api.trace.Tracer tracer (otel-name id))]
                (.setStartTimestamp sb ^java.time.Instant inst)
+               (when (not= :internal span-kind)
+                 (.setSpanKind sb (case span-kind
+                                    :client io.opentelemetry.api.trace.SpanKind/CLIENT
+                                    :consumer io.opentelemetry.api.trace.SpanKind/CONSUMER
+                                    :producer io.opentelemetry.api.trace.SpanKind/PRODUCER
+                                    :server io.opentelemetry.api.trace.SpanKind/SERVER
+                                    io.opentelemetry.api.trace.SpanKind/INTERNAL)))
                (.with ^io.opentelemetry.context.Context parent-context
                  (.startSpan sb)))))))))
 
 (comment
-  (enc/qb 1e6 (otel-context) (otel-context+span ::id1 (enc/now-inst) nil)) ; [46.42 186.89]
+  (enc/qb 1e6 (otel-context) (otel-context+span ::id1 (enc/now-inst) nil nil)) ; [46.42 186.89]
   (viable-tracer (force taoensso.telemere/*otel-tracer*))
   (otel-trace-id (otel-context)))
 
@@ -689,9 +696,10 @@
 
                  ;; Trace with OpenTelemetry
                  (and clj? enabled:otel-tracing?)
-                 `[~'__otel-context0 ~(get opts :otel/context `(otel-context)) ; Context
-                   ~'__otel-context1 ~(if run-form `(otel-context+span ~'__id ~'__inst ~'__otel-context0) ~'__otel-context0)
-                   ~'__uid           ~(auto-> uid-form `(or (otel-span-id ~'__otel-context1) (com.taoensso.encore.Ids/genHexId16)))
+                 `[~'__otel-context0  ~(get opts :otel/context `(otel-context)) ; Context
+                   ~'__otel-span-kind ~(get opts :otel/span-kind :internal)
+                   ~'__otel-context1  ~(if run-form `(otel-context+span ~'__id ~'__inst ~'__otel-context0 ~'__otel-span-kind) ~'__otel-context0)
+                   ~'__uid            ~(auto-> uid-form `(or (otel-span-id ~'__otel-context1) (com.taoensso.encore.Ids/genHexId16)))
                    ~'__root1
                    (or ~'__root0
                      ~(when trace?

--- a/projects/main/src/taoensso/telemere/open_telemetry.clj
+++ b/projects/main/src/taoensso/telemere/open_telemetry.clj
@@ -244,6 +244,9 @@
     `:otel/attrs`       - Attributes [1] to add to log records AND tracing spans/events
     `:otel/log-attrs`   - Attributes [1] to add to log records ONLY
     `:otel/trace-attrs` - Attributes [1] to add to tracing spans/events ONLY
+    `:otel/span-kind`   - The span kind, one of `:internal`, `:server`, `:client`,
+                          `:producer`, `:consumer`. Default is `:internal`. Any other
+                          kind will result in an internal span as well.
 
   [1] `io.opentelemetry.api.common.Attributes` or Clojure map with str/kw keys and vals ∈
       #{nil boolean keyword string UUID long double string-vec long-vec double-vec boolean-vec}.


### PR DESCRIPTION
Adds support for setting the span kind, as discussed [on slack](https://clojurians.slack.com/archives/C06ALA6EEUA/p1734102278244169?thread_ts=1734099062.896279&cid=C06ALA6EEUA.).

This adds an optional signal key `:otel/span-kind` that propagates the span kind into the SpanBuilder.