### PR TITLE
Denoise the API docs a bit

### DIFF
--- a/main/src/taoensso/telemere.cljc
+++ b/main/src/taoensso/telemere.cljc
@@ -5,7 +5,6 @@
     <https://www.taoensso.com/telemere>"
 
   {:author "Peter Taoussanis (@ptaoussanis)"}
-  (:refer-clojure :exclude [newline])
   (:require
    [taoensso.truss          :as truss]
    [taoensso.encore         :as enc]
@@ -69,13 +68,11 @@
 
 (enc/defaliases
   ;; Encore
-  #?(:clj enc/set-var-root!)
-  #?(:clj enc/update-var-root!)
+  #?(:clj ^:no-doc enc/set-var-root!)
+  #?(:clj ^:no-doc enc/update-var-root!)
   #?(:clj enc/get-env)
   #?(:clj enc/call-on-shutdown!)
-  enc/chance
   enc/rate-limiter
-  enc/newline
   sigs/comp-xfn
   #?(:clj truss/keep-callsite)
 

--- a/main/src/taoensso/telemere/utils.cljc
+++ b/main/src/taoensso/telemere/utils.cljc
@@ -134,7 +134,7 @@
 ;;;; Misc
 
 (enc/defaliases
-  enc/newline enc/pr-edn #?(:clj enc/uuid) enc/uuid-str
+  enc/newline enc/pr-edn #?(:clj enc/uuid) enc/uuid-str enc/chance
   #?@(:cljs [enc/pr-json])
   #?@(:clj  [enc/thread-info enc/thread-id enc/thread-name
              enc/host-info   enc/host-ip   enc/hostname]))


### PR DESCRIPTION
Hi Peter!

This is a small proposal that is aimed to "denoise" the [API docstrings](https://cljdoc.org/d/com.taoensso/telemere/CURRENT/api/taoensso.telemere).

The library's API is already quite extensive and detailed. I believe there's no need to intimidate a user even more. 😅 

<details>
<summary>This is what it looks like in the docs now.</summary>
<img width="1200" alt="Снимок экрана 2025-05-01 в 17 48 57" src="https://github.com/user-attachments/assets/65c4b3fb-6402-419d-9682-d9acd3e592be" />
<img width="1200" alt="Снимок экрана 2025-05-01 в 17 50 46" src="https://github.com/user-attachments/assets/03c4f919-b646-45f0-be74-acb0ae7395c3" />
<img width="1200" alt="Снимок экрана 2025-05-01 в 17 49 58" src="https://github.com/user-attachments/assets/1ac85d21-9993-4abf-8560-1dc92a64fcbe" />
</details>

What's proposed:
- hide API docstrings for the `set-var-root!` and `update-var-root!`
- do not expose `newline` and `chance` in the `taoensso.telemere` ns
- move `chance` to the `taoensso.telemere.utils` ns (`newline` is already there)

Do you think it's worth doing this now, right after the 1.0.0 release? Or is it too late?

Cheers,
Mark