### PR TITLE
Fix handling of unset slf4j timestamp

### DIFF
--- a/slf4j/src/taoensso/telemere/slf4j.clj
+++ b/slf4j/src/taoensso/telemere/slf4j.clj
@@ -143,7 +143,10 @@
 
   ;; Modern "fluent" API calls
   ([logger-name ^org.slf4j.event.LoggingEvent event]
-   (let [inst         (or (when-let [ts (.getTimeStamp event)] (java.time.Instant/ofEpochMilli ts)) (enc/now-inst*))
+   (let [ts           (.getTimeStamp event)
+         inst         (if (pos? ts)
+                        (java.time.Instant/ofEpochMilli ts)
+                        (enc/now-inst*))
          level        (.getLevel     event)
          error        (.getThrowable event)
          msg-pattern  (.getMessage   event)


### PR DESCRIPTION
Given that [LoggingEvent.getTimestamp](https://javadoc.io/static/org.slf4j/slf4j-api/2.0.7/org/slf4j/event/LoggingEvent.html#getTimeStamp()) returns a primitive `long`, the value cannot be nil, so `when-let` wasn't catching when the timestamp wasn't set